### PR TITLE
#12 VerboseProcess.Monitor: Moved countDown() after closure of streams

### DIFF
--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -344,7 +344,6 @@ public final class VerboseProcess {
                     writer.write(line);
                     writer.newLine();
                 }
-                this.done.countDown();
             } finally {
                 try {
                     reader.close();
@@ -355,6 +354,7 @@ public final class VerboseProcess {
                         "failed to close reader: %[exception]s", ex
                     );
                 }
+                this.done.countDown();
             }
             return null;
         }


### PR DESCRIPTION
Let's try this again. My new hypothesis is that `countDown()` being called before the streams are closed causes a race condition where the output may read before it's flushed. This will be more likely to manifest in mutlithreaded environments like Travis, which may explain my difficulty in reproducing it locally.
