### PR TITLE
Implement disabling text coloring

### DIFF
--- a/src/test/java/com/jcabi/log/MulticolorLayoutTest.java
+++ b/src/test/java/com/jcabi/log/MulticolorLayoutTest.java
@@ -41,6 +41,19 @@ import org.mockito.Mockito;
  * Test case for {@link MulticolorLayout}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
+ * @todo #54:30min Create an integration test for testing if MulticolorLayout
+ *  will disable text coloring when an application is run with
+ *  `-Dcom.jcabi.log.coloring=false`.
+ *  ...
+ *  Intergration testing is required because this can't be done in a unit test:
+ *  ...
+ *  - We can't just pass a parameter to `MulticolorLayout` that determines if
+ *  the layout should color its output, because Log4J requires
+ *  EnhancedPatternLayout to have a 0-arguments constructor.
+ *  - We can't disable coloring with something like
+ *  `MulticolorLayout#setColoring(boolean)`, too, (that would be unit-testable)
+ *  because Log4J won't know how to call that.
+ *  - `System.getProperty(String)` is not mockable for obvious reasons.
  */
 public final class MulticolorLayoutTest {
 


### PR DESCRIPTION
When logs are required not for a terminal, coloring gets in the way:

    [0;37mINFOm] ...

because color coding makes sense only in a terminal's output.

This is alleviated in this PR with the introduction of `-Dcom.jcabi.log.coloring` system property. When it is set to `"false"`, `MulticolorLayout` won't insert color coding to the text it outputs.

Unfortunately, I couldn't unit test it (details are in a `@todo`) for `MulticolorLayoutTest`, I suggest integration testing for this feature.

For #54 