### PR TITLE
make jcabi-log a valid OSGI bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <artifactId>jcabi-log</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>jcabi-log</name>
+    <packaging>bundle</packaging>
     <description>Wrapper of SLF4J and a few supplementary logging classes</description>
     <issueManagement>
         <system>github</system>
@@ -107,6 +108,12 @@
                         <file.encoding>Cp1251</file.encoding>
                     </systemPropertyVariables>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.0</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
use the maven-bundle-plugin to make jcabi-log a valid OSGI bundle