### PR TITLE
Fixed MultiColorLayoutIntegrationTest

### DIFF
--- a/src/it/it-decoloring/src/test/java/com/jcabi/log/MulticolorLayoutIntegrationTest.java
+++ b/src/it/it-decoloring/src/test/java/com/jcabi/log/MulticolorLayoutIntegrationTest.java
@@ -34,7 +34,6 @@ import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -134,7 +133,6 @@ public final class MulticolorLayoutIntegrationTest {
      * @throws Exception - if something goes wrong.
      */
     @Test
-    @Ignore
     public void disablesConstantColor() throws Exception {
         final MulticolorLayout layout = new MulticolorLayout();
         layout.setConversionPattern("[%color-blue{%p}] %color-blue{%m}");
@@ -169,7 +167,6 @@ public final class MulticolorLayoutIntegrationTest {
      * @throws Exception - if something goes wrong.
      */
     @Test
-    @Ignore
     public void disablesOverridenConstantColor() throws Exception {
         final MulticolorLayout layout = new MulticolorLayout();
         layout.setConversionPattern("[%color-red{%p}] %color-red{%m}");

--- a/src/main/java/com/jcabi/log/ColorfullyFormatted.java
+++ b/src/main/java/com/jcabi/log/ColorfullyFormatted.java
@@ -29,9 +29,6 @@
  */
 package com.jcabi.log;
 
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * Formats a log event using ANSI color codes.
  * @author Jose V. Dal Pra Junior (jrdalpra@gmail.com)

--- a/src/main/java/com/jcabi/log/ColorfullyFormatted.java
+++ b/src/main/java/com/jcabi/log/ColorfullyFormatted.java
@@ -29,6 +29,9 @@
  */
 package com.jcabi.log;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Formats a log event using ANSI color codes.
  * @author Jose V. Dal Pra Junior (jrdalpra@gmail.com)
@@ -63,8 +66,8 @@ class ColorfullyFormatted implements Formatted {
      */
     @Override
     public String format() {
-        return this.basic.replace(
-            new ControlSequenceIndicatorFormatted("%s?m").format(),
+        return this.basic.replaceAll(
+            new ControlSequenceIndicatorFormatted("%s\\?m").format(),
             String.format(
                 "%s%sm",
                 new ControlSequenceIndicatorFormatted("%s").format(),

--- a/src/main/java/com/jcabi/log/ControlSequenceIndicatorFormatted.java
+++ b/src/main/java/com/jcabi/log/ControlSequenceIndicatorFormatted.java
@@ -41,7 +41,6 @@ public class ControlSequenceIndicatorFormatted implements Formatted {
      * Pattern to be used to find replacement points.
      */
     private final transient String pattern;
-
     /**
      * Construtor.
      * @param pat Pattern to be used to find replacement points
@@ -52,7 +51,7 @@ public class ControlSequenceIndicatorFormatted implements Formatted {
 
     @Override
     public final String format() {
-        return String.format(this.pattern, "\u001b[");
+        return String.format(this.pattern, "\u001b\\[");
     }
 
 }

--- a/src/main/java/com/jcabi/log/ControlSequenceIndicatorFormatted.java
+++ b/src/main/java/com/jcabi/log/ControlSequenceIndicatorFormatted.java
@@ -41,6 +41,7 @@ public class ControlSequenceIndicatorFormatted implements Formatted {
      * Pattern to be used to find replacement points.
      */
     private final transient String pattern;
+
     /**
      * Construtor.
      * @param pat Pattern to be used to find replacement points

--- a/src/main/java/com/jcabi/log/DullyFormatted.java
+++ b/src/main/java/com/jcabi/log/DullyFormatted.java
@@ -57,10 +57,10 @@ class DullyFormatted implements Formatted {
      */
     @Override
     public String format() {
-        return this.basic.replace(
-            new ControlSequenceIndicatorFormatted("%s?m").format(),
+        return this.basic.replaceAll(
+            new ControlSequenceIndicatorFormatted("%s([0-9]*|\\?)m").format(),
             ""
-        ).replace(
+        ).replaceAll(
             new ControlSequenceIndicatorFormatted("%sm").format(),
             ""
         );

--- a/src/main/java/com/jcabi/log/DullyFormatted.java
+++ b/src/main/java/com/jcabi/log/DullyFormatted.java
@@ -60,9 +60,6 @@ class DullyFormatted implements Formatted {
         return this.basic.replaceAll(
             new ControlSequenceIndicatorFormatted("%s([0-9]*|\\?)m").format(),
             ""
-        ).replaceAll(
-            new ControlSequenceIndicatorFormatted("%sm").format(),
-            ""
         );
     }
 

--- a/src/test/java/com/jcabi/log/MulticolorLayoutTest.java
+++ b/src/test/java/com/jcabi/log/MulticolorLayoutTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.log;
 
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
@@ -41,14 +42,6 @@ import org.mockito.Mockito;
  * Test case for {@link MulticolorLayout}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
- * @todo #63:30min Fix bug in method format(LoggingEvent).
- *  The tests disablesOverridenConstantColor() and
- *  disablesConstantColor() from
- *  /src/it/it-decoloring/.../MulticolorLayoutITCase
- *  are currently failing and are ignored.
- *  Problem is that the text isn't decolored correctly when the color
- *  is specified in the conversion pattern.
- *  E.g. "[%color-blue{%p}] %color-blue{%m}" .
  */
 public final class MulticolorLayoutTest {
 
@@ -56,6 +49,7 @@ public final class MulticolorLayoutTest {
      * Conversation pattern for test case.
      */
     private static final String CONV_PATTERN = "[%color{%p}] %color{%m}";
+
     /**
      * MulticolorLayout can transform event to text.
      * @throws Exception If something goes wrong

--- a/src/test/java/com/jcabi/log/MulticolorLayoutTest.java
+++ b/src/test/java/com/jcabi/log/MulticolorLayoutTest.java
@@ -29,7 +29,6 @@
  */
 package com.jcabi.log;
 
-
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;


### PR DESCRIPTION
PR for issue #77  .Some tests for text decoloring were failing. Fixed by formatting strings using regex and String.replaceAll(regex, replacement), instead of blunt text and String.replace(), which looks for strings as they are and does not evaluate regexes. 