### PR TITLE
#74 VerboseProcess fails if logging level was initialized to Level.ALL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utility class for getting {@code stdout} from a running process
@@ -144,10 +145,10 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
-        final String format = new StringBuilder("%s LEVEL can't be set to ALL ")
-                .append("because it is intended only for ")
-                .append("internal configuration")
-                .toString();
+        final String format = StringUtils.join(
+            "%s LEVEL can't be set to ALL because it is ",
+            "intended only for internal configuration"
+        );
         if (Level.ALL.equals(stdout)) {
             throw new IllegalArgumentException(
                 String.format(format, "stdout")

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utility class for getting {@code stdout} from a running process
@@ -145,10 +144,8 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
-        final String format = StringUtils.join(
-            "%s LEVEL can't be set to ALL because it is ",
-            "intended only for internal configuration"
-        );
+        final String format = "%s LEVEL can't be set to ALL because it is "
+            .concat("intended only for internal configuration");
         if (Level.ALL.equals(stdout)) {
             throw new IllegalArgumentException(
                 String.format(format, "stdout")

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -125,7 +125,9 @@ public final class VerboseProcess implements Closeable {
 
     /**
      * Public ctor, with a given process and logging levels for {@code stdout}
-     * and {@code stderr}.
+     * and {@code stderr}. Neither {@code stdout} nor {@code stderr} cannot be
+     * set to {@link Level#ALL} because it is intended to be used only for
+     * internal configuration.
      * @param prc Process to execute and monitor
      * @param stdout Log level for stdout
      * @param stderr Log level for stderr
@@ -142,14 +144,18 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
+        final String format = new StringBuilder("%s LEVEL can't be set to ALL ")
+                .append("because it is intended only for ")
+                .append("internal configuration")
+                .toString();
         if (Level.ALL.equals(stdout)) {
             throw new IllegalArgumentException(
-                "stdout LEVEL can't be set to ALL"
+                String.format(format, "stdout")
             );
         }
         if (Level.ALL.equals(stderr)) {
             throw new IllegalArgumentException(
-                "stderr LEVEL can't be set to ALL"
+                String.format(format, "stderr")
             );
         }
         this.process = prc;

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -142,6 +142,16 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
+        if (Level.ALL.equals(stdout)) {
+            throw new IllegalArgumentException(
+                "stdout LEVEL can't be set to ALL"
+            );
+        }
+        if (Level.ALL.equals(stderr)) {
+            throw new IllegalArgumentException(
+                "stderr LEVEL can't be set to ALL"
+            );
+        }
         this.process = prc;
         this.olevel = stdout;
         this.elevel = stderr;

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -144,14 +144,15 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
-        // @checkstyle LineLength (12 line)
         if (Level.ALL.equals(stdout)) {
             throw new IllegalArgumentException(
+                // @checkstyle LineLength (1 line)
                 "stdout LEVEL can't be set to ALL because it is intended only for internal configuration"
             );
         }
         if (Level.ALL.equals(stderr)) {
             throw new IllegalArgumentException(
+                // @checkstyle LineLength (1 line)
                 "stderr LEVEL can't be set to ALL because it is intended only for internal configuration"
             );
         }

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -144,17 +144,15 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
-        // @checkstyle MultipleStringLiteralsCheck (12 line)
+        // @checkstyle LineLength (12 line)
         if (Level.ALL.equals(stdout)) {
             throw new IllegalArgumentException(
-                "stdout LEVEL can't be set to ALL because "
-                    .concat("it is intended only for internal configuration")
+                "stdout LEVEL can't be set to ALL because it is intended only for internal configuration"
             );
         }
         if (Level.ALL.equals(stderr)) {
             throw new IllegalArgumentException(
-                "stderr LEVEL can't be set to ALL because "
-                    .concat("it is intended only for internal configuration")
+                "stderr LEVEL can't be set to ALL because it is intended only for internal configuration"
             );
         }
         this.process = prc;

--- a/src/main/java/com/jcabi/log/VerboseProcess.java
+++ b/src/main/java/com/jcabi/log/VerboseProcess.java
@@ -144,16 +144,17 @@ public final class VerboseProcess implements Closeable {
         if (stderr == null) {
             throw new IllegalArgumentException("stderr LEVEL can't be NULL");
         }
-        final String format = "%s LEVEL can't be set to ALL because it is "
-            .concat("intended only for internal configuration");
+        // @checkstyle MultipleStringLiteralsCheck (12 line)
         if (Level.ALL.equals(stdout)) {
             throw new IllegalArgumentException(
-                String.format(format, "stdout")
+                "stdout LEVEL can't be set to ALL because "
+                    .concat("it is intended only for internal configuration")
             );
         }
         if (Level.ALL.equals(stderr)) {
             throw new IllegalArgumentException(
-                String.format(format, "stderr")
+                "stderr LEVEL can't be set to ALL because "
+                    .concat("it is intended only for internal configuration")
             );
         }
         this.process = prc;

--- a/src/test/java/com/jcabi/log/VerboseProcessTest.java
+++ b/src/test/java/com/jcabi/log/VerboseProcessTest.java
@@ -182,18 +182,38 @@ public final class VerboseProcessTest {
      * VerboseProcess can reject ALL stdout level.
      * @throws Exception If something goes wrong
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rejectsStdoutWithLevelAll() throws Exception {
-        new VerboseProcess(Mockito.mock(Process.class), Level.ALL, Level.INFO);
+        try {
+            new VerboseProcess(
+                Mockito.mock(Process.class), Level.ALL, Level.INFO
+            );
+            Assert.fail("IllegalArgumentException expected");
+        } catch (final IllegalArgumentException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.equalTo("stdout LEVEL can't be set to ALL")
+            );
+        }
     }
 
     /**
      * VerboseProcess can reject ALL stderr level.
      * @throws Exception If something goes wrong
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rejectsStderrWithLevelAll() throws Exception {
-        new VerboseProcess(Mockito.mock(Process.class), Level.INFO, Level.ALL);
+        try {
+            new VerboseProcess(
+                Mockito.mock(Process.class), Level.INFO, Level.ALL
+            );
+            Assert.fail("IllegalArgumentException expected");
+        } catch (final IllegalArgumentException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.equalTo("stderr LEVEL can't be set to ALL")
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/log/VerboseProcessTest.java
+++ b/src/test/java/com/jcabi/log/VerboseProcessTest.java
@@ -179,6 +179,24 @@ public final class VerboseProcessTest {
     }
 
     /**
+     * VerboseProcess can reject ALL stdout level.
+     * @throws Exception If something goes wrong
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsStdoutWithLevelAll() throws Exception {
+        new VerboseProcess(Mockito.mock(Process.class), Level.ALL, Level.INFO);
+    }
+
+    /**
+     * VerboseProcess can reject ALL stderr level.
+     * @throws Exception If something goes wrong
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsStderrWithLevelAll() throws Exception {
+        new VerboseProcess(Mockito.mock(Process.class), Level.INFO, Level.ALL);
+    }
+
+    /**
      * VerboseProcess can quietly terminate a long-running process.
      * @throws Exception If something goes wrong
      */
@@ -231,7 +249,7 @@ public final class VerboseProcessTest {
             );
         }
         final VerboseProcess process = new VerboseProcess(
-            builder, Level.OFF, Level.ALL
+            builder, Level.OFF, Level.WARNING
         );
         process.stdoutQuietly();
         MatcherAssert.assertThat(
@@ -261,8 +279,8 @@ public final class VerboseProcessTest {
             .when(prc).getErrorStream();
         final VerboseProcess verboseProcess = new VerboseProcess(
             prc,
-            Level.ALL,
-            Level.ALL
+            Level.FINEST,
+            Level.FINEST
         );
         Logger.debug(
             this,

--- a/src/test/java/com/jcabi/log/VerboseProcessTest.java
+++ b/src/test/java/com/jcabi/log/VerboseProcessTest.java
@@ -192,7 +192,12 @@ public final class VerboseProcessTest {
         } catch (final IllegalArgumentException ex) {
             MatcherAssert.assertThat(
                 ex.getMessage(),
-                Matchers.equalTo("stdout LEVEL can't be set to ALL")
+                Matchers.equalTo(
+                    new StringBuilder("stdout LEVEL can't be set to ALL ")
+                        .append("because it is intended only for ")
+                        .append("internal configuration")
+                        .toString()
+                )
             );
         }
     }
@@ -211,7 +216,12 @@ public final class VerboseProcessTest {
         } catch (final IllegalArgumentException ex) {
             MatcherAssert.assertThat(
                 ex.getMessage(),
-                Matchers.equalTo("stderr LEVEL can't be set to ALL")
+                Matchers.equalTo(
+                    new StringBuilder("stderr LEVEL can't be set to ALL ")
+                        .append("because it is intended only for ")
+                        .append("internal configuration")
+                        .toString()
+                )
             );
         }
     }

--- a/src/test/java/com/jcabi/log/VerboseProcessTest.java
+++ b/src/test/java/com/jcabi/log/VerboseProcessTest.java
@@ -41,6 +41,7 @@ import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.WriterAppender;
@@ -193,10 +194,10 @@ public final class VerboseProcessTest {
             MatcherAssert.assertThat(
                 ex.getMessage(),
                 Matchers.equalTo(
-                    new StringBuilder("stdout LEVEL can't be set to ALL ")
-                        .append("because it is intended only for ")
-                        .append("internal configuration")
-                        .toString()
+                    StringUtils.join(
+                        "stdout LEVEL can't be set to ALL because it is ",
+                        "intended only for internal configuration"
+                    )
                 )
             );
         }
@@ -217,10 +218,10 @@ public final class VerboseProcessTest {
             MatcherAssert.assertThat(
                 ex.getMessage(),
                 Matchers.equalTo(
-                    new StringBuilder("stderr LEVEL can't be set to ALL ")
-                        .append("because it is intended only for ")
-                        .append("internal configuration")
-                        .toString()
+                    StringUtils.join(
+                        "stderr LEVEL can't be set to ALL because it is ",
+                        "intended only for internal configuration"
+                    )
                 )
             );
         }


### PR DESCRIPTION
This is for #74.

Now when `VerboseProcess` throws exception when at least one of stdout and stderr level is set to ALL.
