### PR TITLE
#20: expand %n and %% in Logger.format when no arguments are passed

### DIFF
--- a/src/main/java/com/jcabi/log/Logger.java
+++ b/src/main/java/com/jcabi/log/Logger.java
@@ -91,7 +91,7 @@ public final class Logger {
     public static String format(final String fmt, final Object... args) {
         final String result;
         if (args.length == 0) {
-            result = fmt;
+            result = Logger.expandNoArgSpecifiers(fmt);
         } else {
             final PreFormatter pre = PreFormatter.create(fmt, args);
             result = String.format(pre.getFormat(), pre.getArguments());
@@ -425,6 +425,45 @@ public final class Logger {
      */
     public static SupplierLogger withSupplier() {
         return new SupplierLogger();
+    }
+
+    /**
+     * Expand the no-argument format specifiers {@code %n} and {@code %%}
+     * in a single left-to-right pass, leaving every other character intact.
+     *
+     * <p>This is used by {@link #format(String, Object...)} when no
+     * variable arguments are supplied. Without it, a user-friendly call
+     * such as {@code Logger.info(this, "Hello %n")} would log the literal
+     * text {@code "Hello %n"} instead of a line break, because the
+     * "no args" shortcut bypasses {@link String#format(String, Object[])}.
+     *
+     * @param fmt The format string
+     * @return The string with {@code %n} replaced by the system line
+     *  separator and {@code %%} replaced by a single {@code %}
+     */
+    private static String expandNoArgSpecifiers(final String fmt) {
+        final int length = fmt.length();
+        final StringBuilder out = new StringBuilder(length);
+        int idx = 0;
+        while (idx < length) {
+            final char chr = fmt.charAt(idx);
+            if (chr == '%' && idx + 1 < length) {
+                final char next = fmt.charAt(idx + 1);
+                if (next == 'n') {
+                    out.append(System.lineSeparator());
+                    idx += 2;
+                    continue;
+                }
+                if (next == '%') {
+                    out.append('%');
+                    idx += 2;
+                    continue;
+                }
+            }
+            out.append(chr);
+            idx += 1;
+        }
+        return out.toString();
     }
 
     /**

--- a/src/test/java/com/jcabi/log/NoArgTest.java
+++ b/src/test/java/com/jcabi/log/NoArgTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.jcabi.log;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for no-argument format specifiers ({@code %n} and {@code %%})
+ * in {@link Logger#format(String, Object...)} when no var-args are supplied.
+ *
+ * <p>Without a fix for issue #20 the {@code args.length == 0} shortcut in
+ * {@link Logger#format(String, Object...)} returns the format string as-is,
+ * which means {@code %n} and {@code %%} are not expanded — a user calling
+ * {@code Logger.info(this, "Hello %n")} sees the literal text {@code "Hello %n"}
+ * in the log output instead of a line separator.
+ *
+ * @since 1.18
+ */
+final class NoArgTest {
+
+    @Test
+    void expandsNewLineSpecifierWithoutArguments() {
+        MatcherAssert.assertThat(
+            "%n must be expanded to a line separator even without arguments",
+            Logger.format("%n"),
+            Matchers.is(String.format("%n"))
+        );
+    }
+
+    @Test
+    void expandsPercentSpecifierWithoutArguments() {
+        MatcherAssert.assertThat(
+            "%% must be expanded to a single percent sign even without arguments",
+            Logger.format("%%"),
+            Matchers.is("%")
+        );
+    }
+
+    @Test
+    void expandsNewLineInTextWithoutArguments() {
+        MatcherAssert.assertThat(
+            "%n inside a longer text must be expanded even without arguments",
+            Logger.format("Hello %n World"),
+            Matchers.is(String.format("Hello %n World"))
+        );
+    }
+
+    @Test
+    void expandsAdjacentSpecifiersWithoutArguments() {
+        MatcherAssert.assertThat(
+            "adjacent %% and %n must both be expanded even without arguments",
+            Logger.format("%%%n"),
+            Matchers.is(String.format("%%%n"))
+        );
+    }
+
+    @Test
+    void leavesEscapedNewlineLiteralWithoutArguments() {
+        MatcherAssert.assertThat(
+            "%%n must be expanded to literal '%n', not to a line separator",
+            Logger.format("%%n"),
+            Matchers.is("%n")
+        );
+    }
+}


### PR DESCRIPTION
@yegor256 — this PR addresses the residual portion of #20.

The original snippet from the issue (`Logger.info(this, "Number: %d %n Text: %s", 1, "foo")`) no longer throws after commit 9b4a795 ("#20 handle %n and %%"), but the underlying problem reflected in the issue title is still present whenever no var-args are supplied:

| Call | Before this PR | After this PR |
|---|---|---|
| `Logger.format("%n")` | `"%n"` | system line separator |
| `Logger.format("%%")` | `"%%"` | `"%"` |
| `Logger.format("Hello %n World")` | `"Hello %n World"` | `"Hello \n World"` |
| `Logger.format("%%n")` | `"%%n"` | `"%n"` (literal) |

## Root cause

The `args.length == 0` shortcut in `Logger.format(String, Object...)` returned the format string unchanged, bypassing all expansion of no-argument format specifiers.

## Changes

- **`src/main/java/com/jcabi/log/Logger.java`** — replaced the no-args shortcut with a call to a new private helper `expandNoArgSpecifiers(String)`. The helper walks the format string in a single left-to-right pass, expanding only `%n` (to the system line separator) and `%%` (to a literal `%`), and leaves every other character untouched. Behaviour for unmatched specifiers like a stray `%s` with no args is preserved (returned as-is, no exception thrown).
- **`src/test/java/com/jcabi/log/NoArgTest.java`** — five regression tests, each one fails on `master` and passes on the fix:
  - `expandsNewLineSpecifierWithoutArguments`
  - `expandsPercentSpecifierWithoutArguments`
  - `expandsNewLineInTextWithoutArguments`
  - `expandsAdjacentSpecifiersWithoutArguments`
  - `leavesEscapedNewlineLiteralWithoutArguments` (verifies that `%%n` becomes the literal `%n`, not a line separator — same precedence as `String.format`)

## Verification

All 11 CI checks are green (Linux/macOS/Windows JDK 21, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint). `mvn clean install -Pqulice` is also green locally.

Closes #20.